### PR TITLE
Add Code of Conduct, adopted from Geek Feminism wiki

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -78,7 +78,7 @@ is being harassed, or have any other concerns, please contact any member of the
 Community Team at the following addreses:
 
 * Sascha <__________@_______>
-* Brennan <___________@______>
+* Brennan <project.report@teh-void.net>
 * Than <goldenapplesdesign@gmail.com>
 
 If the person who is harassing you is on the team, they will recuse themselves

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -77,7 +77,7 @@ If you are being harassed by a member of The Project, notice that someone else
 is being harassed, or have any other concerns, please contact any member of the
 Community Team at the following addreses:
 
-* Sascha <__________@_______>
+* Sascha <sascha@siekmann.com>
 * Brennan <project.report@teh-void.net>
 * Than <goldenapplesdesign@gmail.com>
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -42,7 +42,7 @@ Harassment includes:
 - Gratuitous or off-topic sexual images or behaviour  in spaces where they’re
   not appropriate.
 - Physical contact and simulated physical contact (eg, textual descriptions
-  like “*hug*” or “*backrub*”) without consent or after a request to stop.
+  like “\*hug\*” or “\*backrub\*”) without consent or after a request to stop.
 - Threats of violence.
 - Incitement of violence towards any individual, including encouraging a person
   to commit suicide or to engage in self-harm.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,122 @@
+Code of Conduct
+---------------
+
+## Shorter version 
+
+The Project is dedicated to providing a harassment-free experience for
+everyone, regardless of gender, gender identity and expression, sexual
+orientation, disability, physical appearance, body size, age, race, or
+religion. We do not tolerate harassment of participants in any form.
+
+This code of conduct applies to all The Project spaces, both online and off,
+including this github repository, our Signal discussion group, and any
+in-person meetings.  Anyone who violates this code of conduct
+may be sanctioned or expelled from these spaces at the discretion of the
+Community Team.
+
+Some The Project spaces may have additional rules in place, which will be made
+clearly available to participants. Participants are responsible for knowing and
+abiding by these rules.
+
+## Longer version 
+
+The Project is dedicated to providing a harassment-free experience for
+everyone. We do not tolerate harassment of participants in any form.
+
+This code of conduct applies to all The Project spaces, including this github repository, our Signal discussion group, and any
+in-person meetings. Anyone who violates this code of conduct may be sanctioned
+or expelled from these spaces at the discretion of the Community Team.
+
+Some The Project spaces may have additional rules in place, which will be made
+clearly available to participants. Participants are responsible for knowing and
+abiding by these rules.
+
+Harassment includes:
+
+- Offensive comments related to gender, gender identity and expression, sexual
+  orientation, disability, mental illness, neuro(a)typicality, physical
+  appearance, body size, age, race, or religion.
+- Unwelcome comments regarding a person’s lifestyle choices and practices,
+  including those related to food, health, parenting, drugs, and employment.
+- Deliberate misgendering or use of ‘dead’ or rejected names.
+- Gratuitous or off-topic sexual images or behaviour  in spaces where they’re
+  not appropriate.
+- Physical contact and simulated physical contact (eg, textual descriptions
+  like “*hug*” or “*backrub*”) without consent or after a request to stop.
+- Threats of violence.
+- Incitement of violence towards any individual, including encouraging a person
+  to commit suicide or to engage in self-harm.
+- Deliberate intimidation.
+- Stalking or following.
+- Harassing photography or recording, including logging online activity for
+  harassment purposes.
+- Sustained disruption of discussion.
+- Unwelcome sexual attention.
+- Pattern of inappropriate social contact, such as requesting/assuming
+  inappropriate levels of intimacy with others
+- Continued one-on-one communication after requests to cease.
+- Deliberate “outing” of any aspect of a person’s identity without their
+  consent except as necessary to protect vulnerable people from intentional
+  abuse.
+- Publication of non-harassing private communication.
+
+The Project prioritizes marginalized people’s safety over privileged people’s
+comfort. The Community Team reserves the right not to act on complaints
+regarding:
+
+- ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
+- Reasonable communication of boundaries, such as “leave me alone,” “go away,”
+  or “I’m not discussing this with you.”
+- Communicating in a ‘tone’ you don’t find congenial
+- Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or
+  assumptions 
+
+### Reporting and Community Team
+
+If you are being harassed by a member of The Project, notice that someone else
+is being harassed, or have any other concerns, please contact any member of the
+Community Team at the following addreses:
+
+* Sascha <__________@_______>
+* Brennan <___________@______>
+* Than <goldenapplesdesign@gmail.com>
+
+If the person who is harassing you is on the team, they will recuse themselves
+from handling your incident. We will respond as promptly as we can.
+
+This code of conduct applies to The Project spaces, but if you are being
+harassed by a member or contributor of The Project outside our spaces, we still
+want to know about it. We will take all good-faith reports of harassment by The
+Project members, especially Community Team, seriously. This includes harassment
+outside our spaces and harassment that took place at any point in time. The
+abuse team reserves the right to exclude people from The Project based on their
+past behavior, including behavior outside The Project spaces and behavior
+towards people who are not in The Project.
+
+In order to protect volunteers from abuse and burnout, we reserve the right to
+reject any report we believe to have been made in bad faith. Reports intended
+to silence legitimate criticism may be deleted without response.
+
+We will respect confidentiality requests for the purpose of protecting victims
+of abuse. At our discretion, we may publicly name a person about whom we’ve
+received harassment complaints, or privately warn third parties about them, if
+we believe that doing so will increase the safety of The Project members or the
+general public. We will not name harassment victims without their affirmative
+consent.
+
+### Consequences 
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+If a participant engages in harassing behavior, Community Team may take any
+action they deem appropriate, up to and including expulsion from all The
+Project spaces and identification of the participant as a harasser to other The
+Project members or the general public.
+
+### License and attribution
+
+This anti-harassment policy is based on the [example policy from the Geek
+Feminism wiki](http://geekfeminism.wikia.com/wiki/Community_anti-harassment),
+created by the Geek Feminism community. The policy is based on the conference
+anti-harassment policy, and is the work of Annalee Flower Horne with assistance
+from Valerie Aurora, Alex Skud Bayley, Tim Chevalier, and Mary Gardiner.


### PR DESCRIPTION
Summary: adopts the example CoC document from Geek Feminism without any substantial changes. Uses the term "Community Team" in all places where GF's document refers to either the RESPONSE TEAM (individuals empowered to respond to incidents of hgarassment on bahalf of the group) or the LEADERSHIP TEAM (which doesn't have any special meaning in this document, but would refer to the governing body in an organization which had one). Lists three email addresses as contact points for the Community Team.

We'll need to follow up with a CONTRIBUTORS document that links to this Code of Conduct, as well as provides guidance on how to get involved either in person or online, how to contribute code, and how we would add people to the project and the Community Team.

Connected to #2