### PR TITLE
Send auth header with all logged-in http requests

### DIFF
--- a/static/src/actions/data.js
+++ b/static/src/actions/data.js
@@ -18,10 +18,10 @@ export function fetchProtectedDataRequest() {
     };
 }
 
-export function fetchProtectedData(token) {
+export function fetchProtectedData() {
     return (dispatch) => {
         dispatch(fetchProtectedDataRequest());
-        data_about_user(token)
+        data_about_user()
             .then(parseJSON)
             .then(response => {
                 dispatch(receiveProtectedData(response.result));

--- a/static/src/actions/events.js
+++ b/static/src/actions/events.js
@@ -27,7 +27,7 @@ export function updateEventRequest() {
     };
 }
 
-export function fetchEvents(token) {
+export function fetchEvents() {
     return (dispatch) => {
         dispatch(fetchEventsRequest());
         get_all_events()
@@ -44,7 +44,7 @@ export function fetchEvents(token) {
 export function createEvent(event, message_id) {
     return (dispatch) => {
         dispatch(updateEventRequest());
-        create_event( event, message_id )
+        create_event(event, message_id)
             .then(parseJSON)
             .then(response => dispatch(receiveEvents(response)))
             .catch(console.log);

--- a/static/src/actions/messages.js
+++ b/static/src/actions/messages.js
@@ -35,10 +35,10 @@ export function postBroadcastRequest() {
     };
 }
 
-export function fetchMessages(token) {
+export function fetchMessages() {
     return (dispatch) => {
         dispatch(fetchMessagesRequest());
-        get_new_messages(token)
+        get_new_messages()
             .then(parseJSON)
             .then(response => {
                 dispatch(receiveMessages(response));

--- a/static/src/actions/tags.js
+++ b/static/src/actions/tags.js
@@ -29,10 +29,10 @@ export function updateTagRequest() {
     };
 }
 
-export function fetchTags(token) {
+export function fetchTags() {
     return (dispatch) => {
         dispatch(fetchTagsRequest());
-        get_all_tags(token)
+        get_all_tags()
             .then(parseJSON)
             .then(response => {
                 dispatch(receiveTags(response));
@@ -43,7 +43,7 @@ export function fetchTags(token) {
     };
 }
 
-export function handleCreateTag(tag, token) {
+export function handleCreateTag(tag) {
     return (dispatch) => {
         dispatch(updateTagRequest());
         create_tag(tag)
@@ -57,7 +57,7 @@ export function handleCreateTag(tag, token) {
     }
 }
 
-export function handleDeleteTag(tag, token) {
+export function handleDeleteTag(tag) {
     return (dispatch) => {
         dispatch(updateTagRequest());
         delete_tag(tag)
@@ -71,7 +71,7 @@ export function handleDeleteTag(tag, token) {
     }
 }
 
-export function handleUpdateTag(tag, token) {
+export function handleUpdateTag(tag) {
     return (dispatch) => {
         dispatch(updateTagRequest());
         update_tag(tag)

--- a/static/src/actions/users.js
+++ b/static/src/actions/users.js
@@ -29,10 +29,10 @@ export function updateUserRequest() {
     };
 }
 
-export function fetchUsers(token) {
+export function fetchUsers() {
     return (dispatch) => {
         dispatch(fetchUsersRequest());
-        get_all_users(token)
+        get_all_users()
             .then(parseJSON)
             .then(response => {
                 dispatch(receiveUsers(response));
@@ -43,7 +43,7 @@ export function fetchUsers(token) {
     };
 }
 
-export function handleUpdateUser(user, token) {
+export function handleUpdateUser(user) {
     return (dispatch) => {
         dispatch(updateUserRequest());
         update_user(user)

--- a/static/src/utils/http_functions.js
+++ b/static/src/utils/http_functions.js
@@ -4,21 +4,16 @@ import axios from 'axios';
 
 const tokenConfig = (token) => ({
     headers: {
-        'Authorization': token, // eslint-disable-line quote-props
+        'Authorization': token || localStorage.getItem('token'), // eslint-disable-line quote-props
     },
 });
+
+const authHeader = () => tokenConfig(localStorage.getItem('token'))
 
 export function validate_token(token) {
     return axios.post('/api/is_token_valid', {
         token,
     });
-}
-
-export function get_github_access() {
-    window.open(
-        '/github-login',
-        '_blank' // <- This is what makes it open in a new window.
-    );
 }
 
 export function create_user(email, password) {
@@ -35,10 +30,6 @@ export function get_token(email, password) {
     });
 }
 
-export function has_github_token(token) {
-    return axios.get('/api/has_github_token', tokenConfig(token));
-}
-
 export function data_about_user(token) {
     return axios.get('/api/user', tokenConfig(token));
 }
@@ -49,54 +40,51 @@ export function get_new_messages(token) {
 
 export function post_new_message(message) {
     const token = localStorage.getItem('token');
-    return axios.post('/api/outgoing', message, tokenConfig(token) );
+    return axios.post('/api/outgoing', message, authHeader() );
 }
 
 export function post_broadcast(message) {
-    const token = localStorage.getItem('token');
-    return axios.post('/api/broadcast', message, tokenConfig(token) );
+    return axios.post('/api/broadcast', message, authHeader() );
 }
 
-export function get_all_users(token) {
-    return axios.get('/api/users', tokenConfig(token));
+export function get_all_users() {
+    return axios.get('/api/users', authHeader());
 }
 
-export function update_user(user, token) {
+export function update_user(user) {
     let { id } = user;
     return axios.post(`/api/user/${id ? id : 'new'}`, {
         user
-    });
+    }, authHeader());
 }
 
-export function get_all_tags(token) {
-    return axios.get('/api/tags', tokenConfig(token));
+export function get_all_tags() {
+    return axios.get('/api/tags', authHeader())
 }
 
-export function create_tag(tag, token) {
+export function create_tag(tag) {
     let { tag_type, tag_name } = tag;
     console.log( tag, tag_type, tag_name );
     return axios.post('/api/create_tag', {
         tag_type,
         tag_name
-    });
+    }, authHeader());
 }
 
-export function delete_tag(tag, token) {
+export function delete_tag(tag) {
     let { id } = tag;
-    return axios.delete(`/api/tag/${id}`, tag );
+    return axios.delete(`/api/tag/${id}`, tag, authHeader() );
 }
 
-export function update_tag(tag, token) {
+export function update_tag(tag) {
     let { id } = tag;
-    return axios.post(`/api/tag/${id ? id : 'new'}`, {
-        tag
-    });
+    return axios.post(`/api/tag/${id ? id : 'new'}`, { tag }, authHeader());
 }
 
-export function get_all_events(token) {
-    return axios.get('/api/events', tokenConfig(token));
+export function get_all_events() {
+    return axios.get('/api/events', {}, authHeader());
 }
 
 export function create_event(event, message_id) {
-    return axios.put('/api/event', { ...event, message_id } );
+    return axios.put('/api/event', { ...event, message_id }, authHeader());
 }

--- a/static/src/utils/http_functions.js
+++ b/static/src/utils/http_functions.js
@@ -82,7 +82,7 @@ export function update_tag(tag) {
 }
 
 export function get_all_events() {
-    return axios.get('/api/events', {}, authHeader());
+    return axios.get('/api/events', authHeader());
 }
 
 export function create_event(event, message_id) {


### PR DESCRIPTION
Updates to the client API requests, so we can use the `requires_auth` decorator for all these API endpoints.